### PR TITLE
[追加] 建築コースでのpvpを禁止、OPの権限レベルを2に設定

### DIFF
--- a/arch-docker-compose.yml
+++ b/arch-docker-compose.yml
@@ -25,6 +25,8 @@ services:
       SPIGET_RESOURCES: 23799,70359,28140,1997
       # 遠隔操作用のパスワード。本番環境の際には必ず任意の値に変更すること。
       RCON_PASSWORD: ${RCON_PASSWORD}
+      PVP: false
+      OP_PERMISSION_LEVEL: 2
     volumes:
       - architecture-server-data:/data
     tty: true


### PR DESCRIPTION
## 概要
建築コースの設定に次の変更を加える
- PVPを禁止
- opコマンドで与えた権限のレベルを2に設定